### PR TITLE
Add xbranch, a tool to (de-)publish git branches

### DIFF
--- a/README
+++ b/README
@@ -3,6 +3,7 @@
 These are a few small utilities for use with XBPS:
 https://github.com/voidlinux/xbps
 
+  xbranch [-d] branch [repository] - (de-)publish a local git branch
   xbulk [-n] [-k] [xbps-src flags...] PKGS... - simple XBPS bulk builder
   xbump PKGNAME [git commit options] - git commit a version bump
   xcheckrestart [-v] - list programs using outdated libraries

--- a/_xtools
+++ b/_xtools
@@ -1,9 +1,21 @@
-#compdef xbulk xbump xdiff xgensum xgrep xlg xlog xls xmindep xnew xnuxnu xoptdiff xq xsrc
+#compdef xbranch xbulk xbump xdiff xgensum xgrep xlg xlog xls xmindep xnew xnuxnu xoptdiff xq xsrc
 
 _xbps  # force autoload
 
+_xtools_all_branches() {
+	compadd "$@" -- cd $(xdistdir) && git branch -a | \
+		awk '/ remotes\/origin/{ print $1 }' | \
+		cut -d "/" -f 3 | grep -v ^HEAD$
+}
+
 _xtools_all_packages() {
 	compadd "$@" -- $(xdistdir)/srcpkgs/*(:t)
+}
+
+_xbranch() {
+	_arguments : \
+		'-d[de-publish branch]' \
+		'*:available branches:_xtools_all_branches'
 }
 
 _xbulk() {
@@ -55,6 +67,7 @@ _xq() {
 
 _xtools() {
 	case "$service" in
+		xbranch) _xbranch "$@";;
 		xbulk) _xbulk "$@";;
 		xbump) _xtools_one_template "$@";;
 		xdiff) _xdiff "$@";;

--- a/xbranch
+++ b/xbranch
@@ -1,0 +1,78 @@
+#!/bin/sh
+# Based on a ruby script by William Morgan (http://git-wt-commit.rubyforge.org/)
+#
+# SYNOPSIS:
+#     xbranch [-d] <branch> [repository]
+#
+# DESCRIPTION:
+#     Publish a branch to the origin or the specified repository.
+#     With -d delete a branch from the origin or the specified repository.
+#     Update local config for branch.<branch>.remote and branch.<branch>.merge
+#     accordingly.
+#
+# HINTS:
+#     The branch is not created or deleted locally, but just (de-)published.
+#     This means you still have to:
+#
+#       git checkout -b <branch>
+#
+#     or similar before publishing it, or to:
+#
+#       git branch [-d|-D] <branch>
+#
+#     after de-publishing it to also delete it locally.
+#
+usage() {
+	echo "Usage: $1 [-d] <branch> [<remote>]"
+	echo "-d\tdelete the branch on origin or <remote>"
+}
+
+head=$(git symbolic-ref HEAD|sed -e"s;/head/refs/;;g")
+
+delete=0
+if [ "x$1" = "x-d" ]; then
+	delete=1
+	shift
+fi
+
+# First parameter is the branch name
+branch=$(echo $1|sed -e"s;/head/refs/;;g")
+if [ -z "$branch" ]; then
+	usage $(basename "$0") && exit 1
+fi
+shift
+
+# A remote may be specified
+remote="$1"
+# Default to origin
+[ -z "$remote" ] && remote=origin
+
+local_ref=$(git show-ref heads/${branch})
+if [ "$delete" -eq "0" ]; then
+	# Add remote branch after sanity checks
+	if [ -z "$local_ref" ]; then
+		echo "No local branch ${branch} exists!"
+		exit 1
+	fi
+	remote_ref=$(git show-ref remotes/${remote}/${branch})
+	if [ -n "$remote_ref" ]; then
+		echo "A remote branch ${branch} already exists!"
+		exit 1
+	fi
+	remote_config=$(git show-ref remotes/${remote}/${branch})
+	if [ -n "$remote_config" ]; then
+		echo "The local branch ${branch} is already a tracking branch!"
+		exit 1
+	fi
+	git push ${remote} ${branch}:refs/heads/${branch}
+	git config branch.${branch}.remote ${remote}
+	git config branch.${branch}.merge refs/heads/${branch}
+else
+	# Delete remote branch
+	git push origin :refs/heads/${branch}
+	if [ -n "$local_ref" ]; then
+		# Remove branch from local config
+		git config --unset branch.${branch}.remote
+		git config --unset branch.${branch}.merge
+	fi
+fi


### PR DESCRIPTION
I'm not sure if the syntax in _xtools is correct. It does not seem to work as expected, i.e. it does not show local branches with bash completion with `xbranch <TAB>`.

Perhaps you can tell what I did wrong here?

I stripped the copyright line off xbranch and it's Public Domain anyway.