### PR TITLE
xlint: don't complain for escaped backticks

### DIFF
--- a/xlint
+++ b/xlint
@@ -140,7 +140,7 @@ for template; do
 	scan 'vinstall.* usr/share/licenses' "use vlicense"
 	scan '^  ' "indent with tabs" | once
 	scan '[\t ]$' "trailing whitespace"
-	scan '`' "use \$() instead of backticks"
+	scan '[^\\]`' "use \$() instead of backticks"
 	scan 'revision=0' "revision must not be zero"
 	scan 'replaces=(?=.*\w)[^<>]*$' "replaces needs depname with version"
 	scan 'conflicts=(?=.*\w)[^<>]*$' "conflicts needs depname with version"


### PR DESCRIPTION
Backticks may appear as e.g. [sed search patterns](https://travis-ci.org/voidlinux/void-packages/jobs/68880668) and should be ignored in that case.
Is the regex ok?