### PR TITLE
xlint: detect MIT, BSD and ISC licenses

### DIFF
--- a/xlint
+++ b/xlint
@@ -132,7 +132,10 @@ for template; do
 	scan 'license=.*[^L]GPL[^-]' "license GPL without version"
 	scan 'license=.*LGPL[^-]' "license LGPL without version"
 	if ! grep -q vlicense "$template"; then
-		scan 'license=.*custom' "license 'custom', but no use of vlicense"
+		# XXX: If license is, (i.e BSD and MIT), sed will fail in the 'scan' function
+		# Hence the 'once'
+		license=$(grep -Po 'custom|MIT|BSD|ISC' $template | once)
+		scan 'license=.*(custom|MIT|BSD|ISC)' "license '$license', but no use of vlicense"
 	fi
 	if ! sed -n '/^version=/{n;/revision=/b;q1}' "$template"; then
 		scan 'revision=' "revision does not appear immediately after version"


### PR DESCRIPTION
Detects use of <code>vlicense</code> if the license is MIT, BSD or ISC. There is one problem I found. On line 137, if the license is, (i.e. both MIT and BSD), <code>sed</code> in the <code>scan</code> function fails. The <code>once</code> is a workaround. Maybe you know better a solution. I'm not much of a regex guru.