### PR TITLE
xlint: detect if version number is duplicated in distfiles

### DIFF
--- a/xlint
+++ b/xlint
@@ -167,6 +167,7 @@ for template; do
 	scan 'distfiles=.*ftp\.mozilla\.org' 'use $MOZILLA_SITE'
 	scan 'distfiles=.*ftp\.gnu\.org/(pub/)?gnu' 'use $GNU_SITE'
 	scan 'distfiles=.*freedesktop\.org/software' 'use $FREEDESKTOP_SITE'
+	scan "distfiles=.*$(sed -n -e 's/"//g;s/\./\\./g;/^version=.../ { s/.*=//p; q}' -e '$ aNOVER' "$template")" 'use ${version}'
 	scan '^wrksrc=(\$\{[^}]+\}|[^${}/])*/.+' 'wrksrc should be a top-level directory'
 	else
 	echo no such template "$template" 1>&2


### PR DESCRIPTION
Of the silly mistakes I've made when creating template files, duplicating the version number in distfiles is something where I thought xlint could pick up on it. This adds that.

The tricky part of this is extracting the version number. The final part using `'$ aNOVER'` ensures that this doesn't match in cases where it doesn't get a version. The first bit strips double quotes. Then dots are quoted. You might want it to also quote other pattern characters to be more robust but only a dot is common in version numbers. Matching `^version=...` will skip the test for very short version numbers to avoid false positives.
