### PR TITLE
xdowngrade: fix musl

### DIFF
--- a/xdowngrade
+++ b/xdowngrade
@@ -7,6 +7,8 @@ xbps-rindex -a $T/*
 pkg=
 for f; do
 	f=${f##*/}
+	f=${f%.*}
+	f=${f%.*}
 	pkg="$pkg ${f%-*}"
 done
 xbps-install -i -R $T -f $pkg


### PR DESCRIPTION
avoid installing `pkgname-version.arch` if filename is `pkgname-version.arch-musl.xbps`