### PR TITLE
xbump: fix bumping of common/shlib changes.

### DIFF
--- a/xbump
+++ b/xbump
@@ -20,10 +20,11 @@ if [ -n "$(echo "$shlibs" | grep -vE "$spkpattern")" ]; then
 	exit 1
 elif [ -n "$shlibs" ]; then
 	git add common/shlibs
+	dirs=common/shlibs
 fi
 
-dirs=$(./xbps-src show "$pkg" |
-	sed -n '/^\(pkgname\|subpackage\)/s/[^:]*:[\t]*/srcpkgs\//p')
+dirs="$dirs $(./xbps-src show "$pkg" |
+	sed -n '/^\(pkgname\|subpackage\)/s/[^:]*:[\t]*/srcpkgs\//p')"
 
 git add $dirs
 


### PR DESCRIPTION
xbump adds `common/shlibs` to staged, but forgets to commit those changes. This PR adds common/shlibs to the dirs variable that will be committed.