### PR TITLE
xlog, xlg: don't get confused by branches

### DIFF
--- a/xlg
+++ b/xlg
@@ -2,4 +2,4 @@
 # xlg PKG - open short commit log for XBPS template
 
 cd $(xdistdir)/srcpkgs
-git log --date=short --pretty='%cd %h%d %cE: %s' "$@"
+git log --date=short --pretty='%cd %h%d %cE: %s' -- "$@"

--- a/xlog
+++ b/xlog
@@ -2,4 +2,4 @@
 # xlog PKG - open commit log for XBPS template
 
 cd $(xdistdir)/srcpkgs
-git log -p "$@"
+git log -p -- "$@"


### PR DESCRIPTION
If there are any branches with the name PKG `xlg PKG` and `xlog
PKG` fail with 

`fatal: ambiguous argument 'PKG': both revision and filename`