### PR TITLE
xlint: don't check for what isn't a problem

### DIFF
--- a/xlint
+++ b/xlint
@@ -149,7 +149,6 @@ for template; do
 	scan '[^\\]`' "use \$() instead of backticks"
 	scan 'revision=0' "revision must not be zero"
 	scan 'replaces=(?=.*\w)[^<>]*$' "replaces needs depname with version"
-	scan 'conflicts=(?=.*\w)[^<>]*$' "conflicts needs depname with version"
 	scan 'maintainer=(?!.*<.*@.*>).*' "maintainer needs email address"
 	scan 'nonfree=' "use repository=nonfree"
 	scan '^(?!\s*('"$variables"'))[^\s=-]+=' \


### PR DESCRIPTION
Manual: If version comparator is not defined (just a package name), the version comparator is automatically set to >=0.
I tried it, and the manual is correct.