### PR TITLE
xrecent: derive default repo from current arch

### DIFF
--- a/xrecent
+++ b/xrecent
@@ -1,7 +1,13 @@
 #!/bin/sh
 # xrecent [REPOURL|XBPS_ARCH] - list packages in repo ordered by build date
 
-repo=http://repo.voidlinux.eu/current/
+case "$(xbps-uhelper arch)" in
+	*-musl)
+		repo=http://muslrepo.voidlinux.eu/current/;;
+	*)
+		repo=http://repo.voidlinux.eu/current/;;
+esac
+
 case "$1" in
 */*)
 	repo=$1;;


### PR DESCRIPTION
So `xrecent` without args works on *-musl.

Unrelated: the formatting doesn't seem to work on musl. package/timestamp are
separated by 2 spaces instead of aligning tabs. I've been unable to track down
the cause for this.