### PR TITLE
Xrevshlib

### DIFF
--- a/_xtools
+++ b/_xtools
@@ -110,6 +110,12 @@ _xrevbump() {
 		':available templates:_xtools_all_packages'
 }
 
+_xsubpkg() {
+	_arguments : \
+		'-m[list only master package]'\
+		'*:package:_xbps_all_packages'
+}
+
 _xtools() {
 	case "$service" in
 		xbulk) _xbulk "$@";;
@@ -134,7 +140,7 @@ _xtools() {
 		xrecent) _xrecent "$@";;
 		xrevbump) _xrevbump "$@";;
 		xsrc) _xtool_one_template "$@";;
-		xsubpkg) _xtool_one_template "$@";;
+		xsubpkg) _xsubpkg "$@";;
 	esac
 }
 

--- a/_xtools
+++ b/_xtools
@@ -139,6 +139,7 @@ _xtools() {
 		xq) _xq "$@";;
 		xrecent) _xrecent "$@";;
 		xrevbump) _xrevbump "$@";;
+		xrevshlib) _xtools_one_template "$@";;
 		xsrc) _xtool_one_template "$@";;
 		xsubpkg) _xsubpkg "$@";;
 	esac

--- a/xrevshlib
+++ b/xrevshlib
@@ -1,0 +1,14 @@
+#!/bin/sh
+# xrevshlib PACKAGE - list packages shlib-dependent on PACKAGE or its subpkgs
+
+pkg="${1?no package name given}"
+
+xsubpkg "$pkg" |
+	xargs -d'\n' -n1 -r xbps-query -R -p shlib-provides -S |
+	sed 's/\.so.*//' |
+	xargs -d'\n' -n1 -r xbps-query -R -p shlib-requires -s |
+	sed 's/-[^- ]*: .*//' |
+	sort -u |
+	xargs -d'\n' -n1 -r xsubpkg -m |
+	sort -u |
+	grep -Fvx "$(xsubpkg -m $pkg)"

--- a/xsubpkg
+++ b/xsubpkg
@@ -1,6 +1,12 @@
 #!/bin/sh
-# xsubpkg PKG - lists all subpackages of a package
+# xsubpkg [-m] PKG - lists all subpackages of a package
+
+followsym="-L"
+
+case "$1" in
+	-m) followsym="-P"; shift
+esac
 
 PKG=$1
 cd $(xdistdir)
-find -L srcpkgs -maxdepth 2 -samefile srcpkgs/"$PKG"/template | cut -d/ -f 2
+find $followsym srcpkgs -maxdepth 2 -samefile srcpkgs/"$PKG"/template | cut -d/ -f 2


### PR DESCRIPTION
Not totally sure why this isn't mergable yet. Will work on that. EDIT: Now mergeable.

A small utility to discern what reverse depends on a package's shlibs. If only one of the shlibs is bumped, does not adequately limit checks to that.

Still quite useful for me.

Also a small patch to enable a flag for `xsubpkg` to print the main package instead of subpackages.

I make no guarentee the zsh is correct. I am not confident enough in my zsh skills to be sure.