### PR TITLE
xlint: fix version special char check

### DIFF
--- a/xlint
+++ b/xlint
@@ -149,7 +149,7 @@ for template; do
 	scan '[\t ]$' "trailing whitespace"
 	scan '[^\\]`' "use \$() instead of backticks"
 	scan 'revision=0' "revision must not be zero"
-	scan 'version=.*[:-].*' "version must not contain the characters : or -"
+	scan '^version=.*[:-].*' "version must not contain the characters : or -"
 	scan 'replaces=(?=.*\w)[^<>]*$' "replaces needs depname with version"
 	scan 'maintainer=(?!.*<.*@.*>).*' "maintainer needs email address"
 	scan 'nonfree=' "use repository=nonfree"


### PR DESCRIPTION
Oops. As is will also catch the current `slurm-wlm` template, which does not have the problem until you look at the `_version` variable.