### PR TITLE
xlint: allow python_version

### DIFF
--- a/xlint
+++ b/xlint
@@ -101,7 +101,7 @@ provides
 pycompile_dirs
 pycompile_module
 pycompile_version
-python_versions
+python_version
 register_shell
 replaces
 repository


### PR DESCRIPTION
`python_versions` was removed in https://github.com/voidlinux/void-packages/commit/4e6576e7a4d11e717ce6e16121bbb1bdb362bb50
`python_version` was added in https://github.com/voidlinux/void-packages/commit/29c37543cf75436b4c602fd1a0f16a11b3c05539