### PR TITLE
Added make_use_env to the list of variables.

### DIFF
--- a/xlint
+++ b/xlint
@@ -84,6 +84,7 @@ make_cmd
 make_dirs
 make_install_args
 make_install_target
+make_use_env
 makedepends
 mutable_files
 noarch


### PR DESCRIPTION
 This variable is used in the void-packages at common/build-style/gnu-makefile.sh to decide if the makefile respects the environment. I need this to complete my cpdup package for void-linux.