### PR TITLE
do not report deleted mapped files in /dev/shm

### DIFF
--- a/xcheckrestart
+++ b/xcheckrestart
@@ -9,6 +9,8 @@ for f in /proc/[0-9]*; do
 		grep -v -e /SYSV \
 			-e /.cache/fontconfig \
 			-e /var/cache/fontconfig \
+			-e /dev/shm \
+			-e /home \
 			-e 'drm mm object' |
 	       	sort -u )
 	if [ "$LIBS" ]; then


### PR DESCRIPTION
Firefox and other software often gets wrongly reported because mapped files inside /home or /dev/shm were deleted.