### PR TITLE
xlint: add sanity checks for reverts

### DIFF
--- a/xlint
+++ b/xlint
@@ -153,6 +153,8 @@ for template; do
 	scan '[^\\]`' "use \$() instead of backticks"
 	scan 'revision=0' "revision must not be zero"
 	scan '^version=.*[:-].*' "version must not contain the characters : or -"
+	scan '^reverts=.*-.*' "reverts only match version_revision"
+	scan '^reverts=(?!.*_.*).*' "reverts without revision"
 	scan 'replaces=(?=.*\w)[^<>]*$' "replaces needs depname with version"
 	scan 'maintainer=(?!.*<.*@.*>).*' "maintainer needs email address"
 	scan 'maintainer=.*<.*@users.noreply.github.com>.*' "maintainer needs a valid address for sending mail"


### PR DESCRIPTION
Please double check the regex. The intention is to detect
`$pkgname-$version_$revision` and missing revisions. xbps-checkvers only
handles `$version_$revision` correctly.