### PR TITLE
xlint: version must not contain or use shell substitution mechanism

### DIFF
--- a/xlint
+++ b/xlint
@@ -153,6 +153,7 @@ for template; do
 	scan '[^\\]`' "use \$() instead of backticks"
 	scan 'revision=0' "revision must not be zero"
 	scan '^version=.*[:-].*' "version must not contain the characters : or -"
+	scan '^version=.*\${.*[:!#%/^,@].*}.*' "version must not use shell variable substitution mechanism"
 	scan '^reverts=.*-.*' "reverts must not contain package name"
 	scan '^reverts=(?!.*_.*).*' "reverts without revision"
 	scan 'replaces=(?=.*\w)[^<>]*$' "replaces needs depname with version"


### PR DESCRIPTION
Following discussion in xbps-package issue https://github.com/voidlinux/void-packages/issues/7805 and PR https://github.com/voidlinux/void-packages/pull/7811 on Manual.md
