### PR TITLE
xlint: require use of vlicense for AGPL

### DIFF
--- a/xlint
+++ b/xlint
@@ -138,7 +138,7 @@ for template; do
 	scan 'license=.*[^L]GPL[^-]' "license GPL without version"
 	scan 'license=.*LGPL[^-]' "license LGPL without version"
 	if ! grep -q vlicense "$template"; then
-		for l in custom MIT BSD ISC; do
+		for l in custom AGPL MIT BSD ISC; do
 			scan "license=.*$l" "license '$l', but no use of vlicense"
 		done
 	fi


### PR DESCRIPTION
AGPL needs to be vlicensed in templates

> 17:43 < Vaelatern> since GPL doesn't customize the license per-project and we have a copy of the GPL on every void system
> 17:43 < nilsson> does that include the AGPL?
> 17:43 < maldridge> no, AGPL needs to be vlicensed
> 17:43 < maldridge> since its a toxic copyright
> 17:43 < nilsson> k, thanks
> 17:44 < north1> xlint should warn you if it needs vlicense
