### PR TITLE
xpcdeps: start matching pkg-config files by the slash

### DIFF
--- a/xpcdeps
+++ b/xpcdeps
@@ -26,7 +26,7 @@ grab_local() {
 	branch=$(git symbolic-ref -q --short HEAD 2>/dev/null)
 	for pkg in hostdir/binpkgs/$branch/* ; do
 		pkg="${pkg##*/}"
-		pcfile="$(xbps-query -i --repository=hostdir/binpkgs/"$branch" -f "${pkg%-*}" | grep "$1.pc")"
+		pcfile="$(xbps-query -i --repository=hostdir/binpkgs/"$branch" -f "${pkg%-*}" | grep "/$1.pc")"
 		if [ -n "$pcfile" ] ; then
 			printf "%s %s\\n" "${pkg%-*}" "$pcfile"
 			touch "$tempdir/$1.pc"


### PR DESCRIPTION
example of problematic behaivour:

$ xpcdeps uhd

will match

gnuradio-uhd.pc from gnuradio

and wrongly tell us that

gnuradio-devel is a dependency due to Requires: gnuradio-runtime